### PR TITLE
Remove Sentry replay integration

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -10,10 +10,7 @@ if (process.env.SENTRY_ENV) {
     environment: process.env.SENTRY_ENV!,
     // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
     tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
-    ],
+    integrations: [Sentry.browserTracingIntegration()],
     // Performance Monitoring
     tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
     // Session Replay


### PR DESCRIPTION
Remove Sentry replay integration since it is unneeded currently, so it is best to remove it as to not collect more information than is needed.