### PR TITLE
Remove redundant HTTP header

### DIFF
--- a/src/services/background.ts
+++ b/src/services/background.ts
@@ -27,9 +27,6 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     try {
       fetch(url, {
         method: "GET",
-        headers: {
-          journal: request.journal,
-        },
       })
         .then((response) => response.json())
         .then((response) => sendResponse(response))

--- a/src/services/mcServices.ts
+++ b/src/services/mcServices.ts
@@ -13,7 +13,6 @@ export async function getStats(journal: string) {
   let response = await chrome.runtime.sendMessage({
     contentScriptQuery: "getdata",
     url: `${process.env.API_BASE_URL}/api/journals/${journal}/stats`,
-    journal: journal,
   });
   return response;
 }


### PR DESCRIPTION
Remove the "journal" HTTP header set when requesting stats of a specific journal since it is redundant information as that information is already present in the URL.