### PR TITLE
Remove redundancy from MS data structure

### DIFF
--- a/src/services/mcServices.ts
+++ b/src/services/mcServices.ts
@@ -1,10 +1,10 @@
-import { Manuscript } from "../types/index";
+import { ManuscriptData } from "../types/index";
 
-export async function sendData(ms: Manuscript[]) {
+export async function sendData(manuscriptData: ManuscriptData) {
   const uploadSuccessful = (await chrome.runtime.sendMessage({
     contentScriptQuery: "postData",
     url: `${process.env.API_BASE_URL}/api/manuscripts/`,
-    data: ms,
+    data: manuscriptData,
   })) as boolean;
   return uploadSuccessful;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,18 +7,26 @@ export interface JournalStats {
 
 export interface Manuscript {
   manuscriptID: string;
-  journal: string;
   decision: string;
   submissionDate: string;
   decisionDate: string;
-  journalFullName: string;
 }
+
+export interface ManuscriptData {
+  journalUrlSlug: string;
+  journalName: string;
+  manuscripts: Manuscript[];
+}
+
+export const newManuscriptData = (): ManuscriptData => ({
+  journalUrlSlug: "",
+  journalName: "",
+  manuscripts: [],
+});
 
 export const newManuscript = (): Manuscript => ({
   manuscriptID: "",
-  journal: "",
   decision: "",
   submissionDate: "",
   decisionDate: "",
-  journalFullName: "",
 });


### PR DESCRIPTION
Change the manuscript data structure sent to backend so that the journal url slug and name appear only once instead of in each manuscript, which removes redundancy since all manuscripts in a request should all belong to the same journal anyway, so it's redundant to include this info in each manuscript. Closes #36 