### PR TITLE
Move common code into common webpack config

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,20 +1,8 @@
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
-const webpack = require("webpack");
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
 
-const plugins = [
-  // Copies manifest.json into /build every build
-  new CopyPlugin({
-    patterns: [
-      { from: "./src/manifest.json", to: "./manifest.json" },
-      { from: "./src/ui" },
-      { from: "./src/assets", to: "./assets" },
-    ],
-  }),
-  new webpack.NormalModuleReplacementPlugin(/src[\\\/]env.ts/, "./env.dev.ts"),
-];
+const plugins = [];
 
 if (process.env.UPLOAD_SOURCEMAPS === "true") {
   plugins.push(

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,46 +1,15 @@
 const { merge } = require("webpack-merge");
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
 const common = require("./webpack.common.js");
-const webpack = require("webpack");
-
-function modify(buffer) {
-  // copy-webpack-plugin passes a buffer
-  var manifest = JSON.parse(buffer.toString());
-
-  // Remove any host permissions not required in production
-  manifest.host_permissions = [`${process.env.API_BASE_URL}/*`];
-
-  // pretty print to JSON with two spaces
-  manifest_JSON = JSON.stringify(manifest, null, 2);
-  return manifest_JSON;
-}
 
 module.exports = merge(common, {
   mode: "production",
   devtool: "source-map",
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(
-      /src[\\\/]env.ts/,
-      "./env.prod.ts"
-    ),
     sentryWebpackPlugin({
       authToken: process.env.SENTRY_AUTH_TOKEN,
       org: "michael-maffie",
       project: "coauthor-extension",
-    }),
-    new CopyPlugin({
-      patterns: [
-        {
-          from: "./src/manifest.json",
-          to: "./manifest.json",
-          transform(content, path) {
-            return modify(content);
-          },
-        },
-        { from: "./src/ui" },
-        { from: "./src/assets", to: "./assets" },
-      ],
     }),
   ],
 });


### PR DESCRIPTION
Move manifest build code into the common webpack config, because the process for building the manifest is the exact same for dev and prod, so this code should live in the common webpack config. This is not the case currently as the same config is duplicated in both dev and prod configs which means that if you change one, you have to remember to change the other which is unideal.