### PR TITLE
Update scraping logic

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -229,7 +229,13 @@ export const manuscriptUploadStatusColumn: {
     this.columnHeader = header;
 
     this.render();
-    const uploadSuccessful = await sendData(globalStore.manuscriptData);
+    const decidedManuscripts = {
+      ...globalStore,
+      manuscripts: globalStore.manuscriptData.manuscripts.filter(
+        (x) => x.decision != "Under Review"
+      ),
+    };
+    const uploadSuccessful = await sendData(decidedManuscripts.manuscriptData);
     this.uploadStatus = uploadSuccessful ? "SUCCESS" : "FAILURE";
     this.render();
   },
@@ -245,12 +251,23 @@ export const manuscriptUploadStatusColumn: {
         }
         break;
       case "SUCCESS":
-        for (const cell of this.columnCells) {
-          const imageElement = cell.children[0] as HTMLImageElement;
-          imageElement.src = chrome.runtime.getURL("assets/greenCheck.png");
-          imageElement.alt = "Green checkmark indicating upload success";
-          imageElement.title =
-            "Manuscript successfully received by Coauthor servers.";
+        for (let i in globalStore.manuscriptData.manuscripts) {
+          if (
+            globalStore.manuscriptData.manuscripts[i].decision != "Under Review"
+          ) {
+            let cell = this.columnCells[i];
+            const imageElement = cell.children[0] as HTMLImageElement;
+            imageElement.src = chrome.runtime.getURL("assets/greenCheck.png");
+            imageElement.alt = "Green checkmark indicating upload success";
+            imageElement.title =
+              "Manuscript successfully received by Coauthor servers.";
+          } else if (
+            globalStore.manuscriptData.manuscripts[i].decision == "Under Review"
+          ) {
+            let cell = this.columnCells[i];
+            cell.innerText =
+              "No: Only manuscripts with decisions are uploaded.";
+          }
         }
         break;
       default:

--- a/src/content.ts
+++ b/src/content.ts
@@ -27,7 +27,10 @@ if (process.env.SENTRY_ENV) {
 const onManuscriptsWithDecisionsPage = (): boolean => {
   const h1Elements = document.getElementsByTagName("h1");
   if (h1Elements.length === 1) {
-    if (h1Elements[0].textContent! === "Manuscripts with Decisions") {
+    if (
+      h1Elements[0].textContent! === "Manuscripts with Decisions" ||
+      "Manuscripts I Have Co-Authored"
+    ) {
       return true;
     }
   }
@@ -62,7 +65,7 @@ const addDecisionsColumn = (ms_dataObject: Manuscript[]) => {
   const authorDashboard = document.getElementById(
     "authorDashboardQueue"
   ) as HTMLTableElement;
-  createHeader("Days Until Decision", 0);
+  createHeader("Days Under Review", 0);
   for (let i = 0; i < ms_dataObject.length; i++) {
     let header = document.createElement("td");
     header.innerText = `Days: ${daysUnderReview(
@@ -165,14 +168,29 @@ const getDecisionInfo = (authorDashboardCell: HTMLTableCellElement) => {
   // Assume structure is `${decision} (${decisionDate})`
   const decisionInfoText = decisionInfoElement.textContent!;
 
-  const tokens = decisionInfoText.split("(");
-  const decision = tokens[0].trim();
-  const decisionDate = tokens[1].slice(0, -1);
-
-  return {
-    decision: decision,
-    decisionDate: decisionDate,
-  };
+  try {
+    const tokens = decisionInfoText.split("(");
+    const decision = tokens[0].trim();
+    const decisionDate = tokens[1].slice(0, -1);
+    return {
+      decision: decision,
+      decisionDate: decisionDate,
+    };
+  } catch (error) {
+    const decision = "Under Review";
+    const decisionDate = new Date();
+    const formattedDate = decisionDate
+      .toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      })
+      .replace(/ /g, "-");
+    return {
+      decision: decision,
+      decisionDate: formattedDate,
+    };
+  }
 };
 
 export const manuscriptUploadStatusColumn: {

--- a/src/content.ts
+++ b/src/content.ts
@@ -229,13 +229,13 @@ export const manuscriptUploadStatusColumn: {
     this.columnHeader = header;
 
     this.render();
-    const decidedManuscripts = {
-      ...globalStore,
-      manuscripts: globalStore.manuscriptData.manuscripts.filter(
-        (x) => x.decision != "Under Review"
-      ),
-    };
-    const uploadSuccessful = await sendData(decidedManuscripts.manuscriptData);
+    const decidedManuscripts: ManuscriptData = structuredClone(
+      globalStore.manuscriptData
+    );
+    decidedManuscripts.manuscripts = decidedManuscripts.manuscripts.filter(
+      (x) => x.decision !== "Under Review"
+    );
+    const uploadSuccessful = await sendData(decidedManuscripts);
     this.uploadStatus = uploadSuccessful ? "SUCCESS" : "FAILURE";
     this.render();
   },
@@ -253,7 +253,8 @@ export const manuscriptUploadStatusColumn: {
       case "SUCCESS":
         for (let i in globalStore.manuscriptData.manuscripts) {
           if (
-            globalStore.manuscriptData.manuscripts[i].decision != "Under Review"
+            globalStore.manuscriptData.manuscripts[i].decision !==
+            "Under Review"
           ) {
             let cell = this.columnCells[i];
             const imageElement = cell.children[0] as HTMLImageElement;
@@ -261,9 +262,7 @@ export const manuscriptUploadStatusColumn: {
             imageElement.alt = "Green checkmark indicating upload success";
             imageElement.title =
               "Manuscript successfully received by Coauthor servers.";
-          } else if (
-            globalStore.manuscriptData.manuscripts[i].decision == "Under Review"
-          ) {
+          } else {
             let cell = this.columnCells[i];
             cell.innerText =
               "No: Only manuscripts with decisions are uploaded.";


### PR DESCRIPTION
Updates the scraping logic for the "Manuscripts I have Co-Authored" page:

### Problem
- Previous implementation would break if a user had a manuscript under review awaiting decision
- This greatly limited the scope of the data we could collect because most manuscripts are coauthored

### Solution:
- Updated implementation scrapes all manuscripts into the global store
- The plugin only submits manuscripts with decisions to the server
- Updates the UI to notify users that manuscripts without decisions are not uploaded to the server

### Test Plan:
- Add a console.log statement on the extension side to list all manuscripts sent to the server.