### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--Please create an issue first before creating a Pull Request. This allows discussion of any proposed changes before you do any work.-->
+
+**Change Details**
+
+Please provide enough information so that others can review your pull request:
+
+Explain the **details** for making this change. What existing problem does the pull request solve? If there is already an issue that includes this information, you may be more brief here, but make sure you include the issue number.
+
+<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
+
+**Test plan (required)**
+
+Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
+
+**Closing issues**
+
+Write `closes #XXXX` here to auto-close the issue that your PR fixes.


### PR DESCRIPTION
Add a pull request description template to standardize pull request descriptions and force PR openers to include all information required to understand the problem being fixed, how to test, and ensure that the PR conforms to repository guidelines.