### PR TITLE
fix: fix scraping firing on unsupported pages

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -29,7 +29,7 @@ const onManuscriptsWithDecisionsPage = (): boolean => {
   if (h1Elements.length === 1) {
     if (
       h1Elements[0].textContent! === "Manuscripts with Decisions" ||
-      "Manuscripts I Have Co-Authored"
+      h1Elements[0].textContent! === "Manuscripts I Have Co-Authored"
     ) {
       return true;
     }


### PR DESCRIPTION
- There is a function that checks what page a user is on. If true, the scraper fires.
- Current logic returns true on unsupported pages.

**Change Details**

Please provide enough information so that others can review your pull request: This PR corrects the scraping logic on the page detection logic. It updates the boolean that incorrectly only included a string in an an OR condition, which always returns true.

**Test plan (required)**

Tested on all unsupported pages to detect an error.

**Closing issues**

Write closes #64   here to auto-close the issue that your PR fixes.
