### PR TITLE
Add extension build workflows

### DIFF
--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -1,0 +1,42 @@
+name: Build Extension
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: string
+        required: true
+
+jobs:
+  build-chrome-extension:
+    environment: ${{ inputs.environment }}
+    name: Build Chrome extension artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: load environment variables for build
+        run: |
+          touch .env.${{ inputs.environment }}.private
+          echo SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.${{ inputs.environment }}.private
+
+          touch .env.${{ inputs.environment }}.public
+          echo API_BASE_URL="${{ vars.API_BASE_URL }}" >> .env.${{ inputs.environment }}.public
+          echo SENTRY_ENV="${{ inputs.environment }}" >> .env.${{ inputs.environment }}.public
+          echo SENTRY_DSN="${{ vars.SENTRY_DSN }}" >> .env.${{ inputs.environment }}.public
+
+      - name: Build extension
+        run: |
+          cross-env NODE_ENV=${{ inputs.environment }} webpack --config webpack.prod.js
+          zip -r chrome-extension-${{ github.event.pull_request.head.sha }}.zip dist
+
+      - name: Archive chrome-extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-${{ github.sha }}
+          path: chrome-extension-${{ github.event.pull_request.head.sha }}.zip

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,16 @@
+name: Build Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: environment
+        required: true
+
+jobs:
+  build-chrome-extension:
+    uses: ./.github/workflows/build-extension-reusable.yml
+    with:
+      environment: ${{ github.event.inputs.environment }}
+    secrets: inherit


### PR DESCRIPTION
**Change Details**

Add extension build workflows to remove need for doing staging and prod builds on developer's local machine. The new change should allow a user to go to the Actions tab and choose whether to build staging or prod. See #67 for more context.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

The workflow needs to be ran to test that it allows the user to choose which environment to build, and that it correctly builds the chosen environment. Unfortunately this workflow cannot be ran until it is merged into main, so the plan is to merge and then test it. This is not ideal but if it turns out it doesn't work the worst that happens is just that the build fails and won't break anything in production.

**Closing issues**

Write `closes #XXXX` here to auto-close the issue that your PR fixes.
