### PR TITLE
Refine extension build workflows

### DIFF
--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -40,4 +40,3 @@ jobs:
         with:
           name: coauthor-${{ github.sha }}
           path: coauthor-${{ github.event.pull_request.head.sha }}.zip
-

--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -1,4 +1,4 @@
-name: Build Extension
+name: Build Extension (reusable workflow)
 
 on:
   workflow_call:
@@ -32,11 +32,11 @@ jobs:
 
       - name: Build extension
         run: |
-          cross-env NODE_ENV=${{ inputs.environment }} webpack --config webpack.prod.js
-          zip -r chrome-extension-${{ github.event.pull_request.head.sha }}.zip dist
+          NODE_ENV=${{ inputs.environment }} webpack --config webpack.prod.js
+          zip -r coauthor-${{ github.event.pull_request.head.sha }}.zip build
 
       - name: Archive chrome-extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: chrome-extension-${{ github.sha }}
-          path: chrome-extension-${{ github.event.pull_request.head.sha }}.zip
+          name: coauthor-${{ github.sha }}
+          path: coauthor-${{ github.event.pull_request.head.sha }}.zip

--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -1,0 +1,42 @@
+name: Build Extension
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: string
+        required: true
+
+jobs:
+  build-chrome-extension:
+    environment: ${{ inputs.environment }}
+    name: Build Chrome extension artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: load environment variables for build
+        run: |
+          touch .env.${{ inputs.environment }}.private
+          echo SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.${{ inputs.environment }}.private
+
+          touch .env.${{ inputs.environment }}.public
+          echo API_BASE_URL="${{ vars.API_BASE_URL }}" >> .env.${{ inputs.environment }}.public
+          echo SENTRY_ENV="${{ inputs.environment }}" >> .env.${{ inputs.environment }}.public
+          echo SENTRY_DSN="${{ vars.SENTRY_DSN }}" >> .env.${{ inputs.environment }}.public
+
+      - name: Build extension
+        run: |
+          cross-env NODE_ENV=${{ inputs.environment }} webpack --config webpack.prod.js
+          zip -r chrome-extension-${{ github.event.pull_request.head.sha }}.zip dist
+
+      - name: Archive chrome-extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-${{ github.sha }}
+          path: chrome-extension-${{ github.event.pull_request.head.sha }}.zip

--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Build extension
         run: |
           NODE_ENV=${{ inputs.environment }} webpack --config webpack.prod.js
-          zip -r coauthor-${{ github.event.pull_request.head.sha }}.zip build
+          zip -r coauthor-${{ github.sha }}.zip build
 
       - name: Archive chrome-extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coauthor-${{ github.event.pull_request.head.sha }}
-          path: coauthor-${{ github.event.pull_request.head.sha }}.zip
+          name: coauthor-${{ github.sha }}
+          path: coauthor-${{ github.sha }}.zip

--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Archive chrome-extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coauthor-${{ github.sha }}
+          name: coauthor-${{ github.event.pull_request.head.sha }}
           path: coauthor-${{ github.event.pull_request.head.sha }}.zip

--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -7,6 +7,10 @@ on:
         description: "Target environment"
         type: string
         required: true
+      archive-name:
+        description: "Name of archived build file"
+        type: string
+        required: true
 
 jobs:
   build-chrome-extension:
@@ -33,10 +37,9 @@ jobs:
       - name: Build extension
         run: |
           NODE_ENV=${{ inputs.environment }} webpack --config webpack.prod.js
-          zip -r coauthor-${{ github.sha }}.zip build
 
-      - name: Archive chrome-extension artifact
+      - name: Archive extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coauthor-${{ github.sha }}
-          path: coauthor-${{ github.sha }}.zip
+          name: "${{inputs.archive-name}}"
+          path: build

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,16 @@
+name: Build Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: environment
+        required: true
+
+jobs:
+  build-chrome-extension:
+    uses: ./.github/workflows/build-extension-reusable.yml
+    with:
+      environment: ${{ github.event.inputs.environment }}
+    secrets: inherit

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,4 +1,4 @@
-name: Build Extension
+name: Build Extension (Use to trigger builds)
 
 on:
   workflow_dispatch:
@@ -7,6 +7,8 @@ on:
         description: "Target environment"
         type: environment
         required: true
+
+run-name: Build ${{ github.event.inputs.environment }} extension
 
 jobs:
   build-chrome-extension:

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -15,4 +15,5 @@ jobs:
     uses: ./.github/workflows/build-extension-reusable.yml
     with:
       environment: ${{ github.event.inputs.environment }}
+      archive-name: coauthor-${{ github.sha }}
     secrets: inherit


### PR DESCRIPTION
**Change Details**
Improves upon #68:
- Fix bug that completely broke the workflow
- Make workflow run title include the target environment for clarity
- Rename outputted archive name to match extension name
- Pass archive name as an input to the callable build workflow to give caller workflows control over the name.
- Don't zip the build before passing to upload action as the action
  already zips the build, so zipping before is unnecessary and also
  results in zip inside a zip which is not the structure
  the chrome web store accepts.

**Test plan (required)**
Was able to run the workflow with "staging" option and obtain the archived extension. Downloaded extension and verified that all functionality works.

**Closing issues**

Write `closes #XXXX` here to auto-close the issue that your PR fixes.
