### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,6 +27,7 @@ jobs:
   build-chrome-extension:
     name: Build extension
     needs: [check-for-version-bump]
+    if: needs.check-for-version-bump.outputs.version-bump-found == '0'
     uses: ./.github/workflows/build-extension-reusable.yml
     with:
       environment: production
@@ -46,6 +47,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coauthor-${{needs.check-for-version-bump.outputs.version}}
+          path: ./build
+
+      # download artifact action unzips on download (not configurable) so must zip up again
+      - name: Archive build
+        run: |
+          zip -r coauthor-${{needs.check-for-version-bump.outputs.version}}.zip build
 
       - name: Install webstore cli
         run: |
@@ -66,7 +73,6 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: needs.check-for-version-bump.outputs.version-bump-found == '0'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**Change Details**

Please provide enough information so that others can review your pull request:
Fix more problems with the release workflow:
- Make all jobs dependent on the version bump detection job completing, since no other jobs should run if no version bump is detected.
- Rezip build after downloading it using actions/download-artifact, because it actually unzips on download (not configurable) so we must zip up again before we can upload to the chrome web store.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

**Closing issues**

Write `closes #XXXX` here to auto-close the issue that your PR fixes.
