### PR TITLE
ci: use right node version for workflow job

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,9 +39,6 @@ jobs:
     needs: [build-chrome-extension, check-for-version-bump]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2-beta
-        with:
-          node-version: "16.10"
       # must use this to access previously uploaded artifact
       - name: Download bundle artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
**Change Details**

Use node version that comes preinstalled with with ubuntu-latest (18.20 currently) for extension upload job. The language features used in the extension upload command are not available in 16.10 (the prior Node version used) but are available in 18.17 and higher. Therefore the preinstalled version works.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

**Closing issues**

Write `closes #XXXX` here to auto-close the issue that your PR fixes.
