### PR TITLE
Make help page URL link in popup clickable

### DIFF
--- a/src/ui/ui.html
+++ b/src/ui/ui.html
@@ -44,7 +44,10 @@
     <p>
       The Coauthor Plugin is installed and ready to use.
       <br />
-      <br />For help using Coauthor, visit: https://coauthor.fly.dev/Contribute
+      <br />For help using Coauthor, visit:
+      <a href="https://coauthor.fly.dev/Contribute" target="_blank"
+        >https://coauthor.fly.dev/Contribute</a
+      >
       <br />
       <br />
       If you have questions or discover bugs, e-mail: maffielab@gmail.com


### PR DESCRIPTION

<!--Please create an issue first before creating a Pull Request. This allows discussion of any proposed changes before you do any work.-->

**Change Details**

Please provide enough information so that others can review your pull request:

Make the help page URL in the extension popup clickable and automatically open the page in a new tab when clicked for better UX. See #79 

**Test plan (required)**

Opened the extension popup in the browser and confirmed that clicking the URL does in fact open the instructions page in a new tab. Tested on Chrome and Brave browser.

https://github.com/user-attachments/assets/de32dbc0-195e-414a-ab79-463b6cc86752

**Closing issues**

Write `closes #XXXX` here to auto-close the issue that your PR fixes.
