### PR TITLE
Name release asset correctly

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,11 +19,14 @@ jobs:
         run: |
           version=$(node -p "require('./package.json').version")
           echo "VERSION=$version" >> $GITHUB_OUTPUT
+          echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Construct archive name using release version
         id: "get-archive-name"
         run: |
-          echo "ARCHIVE_NAME=coauthor-$version" >> $GITHUB_OUTPUT
+          echo "ARCHIVE_NAME=coauthor-$VERSION" >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{env.VERSION}}
 
   build-chrome-extension:
     name: Build extension


### PR DESCRIPTION
<!--Please create an issue first before creating a Pull Request. This allows discussion of any proposed changes before you do any work.-->

**Change Details**

Tweak the release workflow so that the release version is properly passed to the release asset naming step so that it correctly names the release asset. Refer to #87 

**Test plan (required)**

Ran the workflow through Github Actions VSCode extension which guarantees the correctness of some things, like that syntax is valid and all referenced jobs/job outputs are valid. However, the workflow has not been actually run yet which is needed to guarantee correctness. But running the workflow would attempt to create a new release, but we don't want to create a release right now. So the plan is to test it when a new release is done.

**Closing issues**

Closes #87 