### PR TITLE
Make release zip easier to load in browser

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,12 +47,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{needs.get-release-info.outputs.archive-name}}
-          path: ./build
+          path: "./${{needs.get-release-info.outputs.archive-name}}"
 
       # download artifact action unzips on download (not configurable) so must zip up again
       - name: Archive build
         run: |
-          zip -r ${{needs.get-release-info.outputs.archive-name}}.zip build
+          (cd "./${{needs.get-release-info.outputs.archive-name}}"; zip -r "../${{needs.get-release-info.outputs.archive-name}}.zip" ./)
 
       - name: Install webstore cli
         run: |
@@ -100,12 +100,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{needs.get-release-info.outputs.archive-name}}
-          path: ./build
+          path: "./${{needs.get-release-info.outputs.archive-name}}"
 
       # download artifact action unzips on download (not configurable) so must zip up again
       - name: Archive build
         run: |
-          zip -r ${{needs.get-release-info.outputs.archive-name}}.zip build
+          (cd "./${{needs.get-release-info.outputs.archive-name}}"; zip -r "../${{needs.get-release-info.outputs.archive-name}}.zip" ./)
 
       - name: Create release on GitHub
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
**Change Details**

Tweak release workflow so that when zipping the extension build that is attached to the release on GitHub, the path to manifest.json is no longer `zipped_dir/build/manifest.json`, but instead `zipped_dir/manifest.json` (at the root of the zipped directory) Because (Chromium) browsers expect the manifest to be in the root of the directory specified to load the extension from, this new dir structure makes figuring out which directory to load simple, since devs can just specify the top-level directory and not have to go down another level to top-level-dir/build. See #92 for more context.

**Test plan (required)**
Zipping is done using a bash command, so to change the zipping behavior to the above, I needed to tweak that bash command. I tested that the new command does the desired behavior by running it on WSL on my local machine, which is an Ubuntu environment same as the environment that the release workflow runs in, so it should also work there.

**Closing issues**

Closes #92 
