### PR TITLE
Link directly to usage guide in onboarding page

### DIFF
--- a/src/ui/onboarding/onboarding.html
+++ b/src/ui/onboarding/onboarding.html
@@ -15,11 +15,22 @@
     <h1>Thanks for downloading Coauthor!</h1>
     <p>The Coauthor browser extension is installed and ready to use.</p>
     <h2>What's next?</h2>
-    Visit
-    <a href="https://coauthor.fly.dev/contribute" target="_blank"
-      >https://coauthor.fly.dev/contribute</a
-    >
-    to learn how to start contributing data.
+    <ul>
+      <li>
+        Visit
+        <a href="https://github.com/MaffieLab/Coauthor/wiki" target="_blank"
+          >https://github.com/MaffieLab/Coauthor/wiki</a
+        >
+        to learn how to use the extension.
+      </li>
+      <li>
+        Visit
+        <a href="https://coauthor.fly.dev" target="_blank"
+          >https://coauthor.fly.dev</a
+        >
+        to see global journal statistics.
+      </li>
+    </ul>
     <br />
     <br />
     Questions? Feedback? e-mail: maffielab@gmail.com


### PR DESCRIPTION
<!--Please create an issue first before creating a Pull Request. This allows discussion of any proposed changes before you do any work.-->

**Change Details**

- Update the link to the usage guide since the guide moved to a new page. The old link would still direct users to the guide (it links to a page that links to the new page) but that's not good UX since the user needs to do two link hops before reaching the destination. Cut the middleman out and let the user go directly to the guide in one click - better UX.
- Add a new link to the frontpage of the main website, so users know of its existence. This is needed because of the above change: previously the extension usage guide was on the main website, so the main website was linked on the onboarding page. Now the guide has moved to a page not on the main website so the main website would not be linked anymore if we didn't also explicitly add a new link.

See #94 

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

New onboarding page:
![image](https://github.com/user-attachments/assets/06c71634-4466-46a1-a4e8-b2e4a1102816)

Testing links:


https://github.com/user-attachments/assets/96790583-a7fe-481a-98e3-4f856c7f364e


**Closing issues**

Closes #94 
